### PR TITLE
Fixed buggy/unintuitive blank-journal states

### DIFF
--- a/TurtleJournal/functions.lua
+++ b/TurtleJournal/functions.lua
@@ -438,17 +438,17 @@ tj:RegisterModule("functions", function()
             return false
         end
 
-        -- hurray
-        tj.frames.leftScrollFrame:SetVerticalScroll(0)
-        d:print("Entry ".. d.colors.green .."saved|r.")
-
         -- refresh the entry list
+        tj.frames.leftScrollFrame:SetVerticalScroll(0)
         tj.UpdateEntryList()
 
         d:debug("Added entry #" .. noteIdx .. " on " .. dateStr)
         
         if makeNew then
             tj.currentViewingEntry = {dateStr = dateStr, entryId = noteIdx}
+            d:print("Entry ".. d.colors.green .."created|r.")
+        else
+            d:print("Entry ".. d.colors.green .."saved|r.")
         end
 
         return true
@@ -510,9 +510,7 @@ tj:RegisterModule("functions", function()
             end
 
             -- refresh the entry list
-            tj.UpdateEntryList(dateStr)
-            tj.frames.editBox:SetText("")
-            tj.frames.titleEditBox:SetText("")
+            tj.UpdateEntryList()
 
             -- hide the entire popup after successful deletion
             StaticPopup_Hide("TURTLEJOURNAL_DELETE_CONFIRM")

--- a/TurtleJournal/functions.lua
+++ b/TurtleJournal/functions.lua
@@ -439,7 +439,6 @@ tj:RegisterModule("functions", function()
         end
 
         -- refresh the entry list
-        tj.frames.leftScrollFrame:SetVerticalScroll(0)
         tj.UpdateEntryList()
 
         d:debug("Added entry #" .. noteIdx .. " on " .. dateStr)

--- a/TurtleJournal/gui.lua
+++ b/TurtleJournal/gui.lua
@@ -246,10 +246,16 @@ tj:RegisterModule("gui", function ()
                 end
             end
 
-            -- if no entries, we're done
+            -- No entries exist, not even the auto-generated default one
             if not next(allEntries) then
                 tj.frames.sideEntryList.buttons = {}
                 leftScrollChild:SetHeight(leftScrollFrame:GetHeight())
+                
+                -- make a new blank one so we never get a state where the page is empty as behavior then is unintuitive
+                editBox:SetText("")
+                titleEditBox:SetText("Title")
+                titleEditBox:SetFocus()
+                tj.SaveEntry(true)
                 return
             end
 
@@ -272,6 +278,7 @@ tj:RegisterModule("gui", function ()
 
             local buttonHeight = 25
             local offset = 15
+            local firstEntry = true
 
             -- create buttons using sorted entries
             for _, sortedEntry in ipairs(sortedEntries) do
@@ -325,6 +332,16 @@ tj:RegisterModule("gui", function ()
 
                 tj.frames.sideEntryList.buttons[compoundId] = button
                 offset = offset + buttonHeight + 2
+                
+                if firstEntry and not tj.selectedEntry then
+                    leftScrollFrame:SetVerticalScroll(0)
+                    tj.selectedEntry = button.entryData
+                    tj.selectedButton = button
+                    button:LockHighlight()
+                    tj.DisplayEntry(button.entryData.dateStr, button.entryData.id)
+                end
+                
+                firstEntry = false
             end
         end
 
@@ -479,12 +496,12 @@ tj:RegisterModule("gui", function ()
             ScrollToTop()
             titleEditBox:SetText("Title")
             titleEditBox:SetFocus()
-            tj.SaveEntry(true)
             tj.selectedEntry = nil
             if tj.selectedButton then
                 tj.selectedButton:UnlockHighlight()
                 tj.selectedButton = nil
             end
+            tj.SaveEntry(true)
         end)
         newButton:SetScript("OnEnter", function()
             GameTooltip:SetOwner(this, "ANCHOR_RIGHT")


### PR DESCRIPTION
Made journal auto open first entry instead of a blank page when first opening. This also fixed so making a new entry properly highlights it in the list and deleting an entry opens the top entry instead of leaving a blank page. Deleting the last entry now also auto-generates a blank one to take its place. There should no longer be any state where you dont have an entry selected as behavior then is unintuitive.

This PR fixes some states i discovered where you delete notes or when you first open the journal and start typing in the empty edit boxes then try to save/delete. You simply cant do it then, cause no note is selected. And selecting one will delete what you wrote and replace it with the selected note. So instead the addon simply never shows an empty edit box with no note selected anymore. It will always force-select a note for you. 

- On first launch it will select the top note. 
- On repeated openings the addon just retains state so it will keep whatever note you had open.
- On creating a new note, it will open it
- On deleting a note, it will open the top note. Or if you deleted the last note, it will make a blank one and select it.